### PR TITLE
Add Standard IRAF copyright file

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,26 @@
+Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
+
+The IRAF software is publicly available, but is NOT in the public domain.
+The difference is that copyrights granting rights for unrestricted use and
+redistribution have been placed on all of the software to identify its authors.
+You are allowed and encouraged to take this software and use it as you wish,
+subject to the restrictions outlined below.
+
+Permission to use, copy, modify, and distribute this software and its
+documentation is hereby granted without fee, provided that the above copyright
+notice appear in all copies and that both that copyright notice and this
+permission notice appear in supporting documentation, and that references to
+the Association of Universities for Research in Astronomy Inc. (AURA),
+the National Optical Astronomy Observatories (NOAO), or the Image Reduction
+and Analysis Facility (IRAF) not be used in advertising or publicity
+pertaining to distribution of the software without specific, written prior
+permission from NOAO.  NOAO makes no representations about the suitability
+of this software for any purpose.  It is provided "as is" without express or
+implied warranty.
+
+NOAO DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL NOAO
+BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN 
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
Fitsutil currently comes without a license attached, which makes it impossible to legally re-distribute (or even use) the package. 
For simplicity, this pull request proposes to use the standard IRAF copyright file here, which is basically a [MIT license type](https://opensource.org/licenses/HPND) (with no-advertizement clause).

The cfitsio license (also MIT license type) is already present in [`lib/cfitsio/License.txt`](https://github.com/iraf/extpkg-fitsutil/blob/eb6995bdfc3fb31f1a02c5351c823fc78c721736/lib/cfitsio/License.txt).