### PR TITLE
Prepare new snapshot version

### DIFF
--- a/fitsutil.par
+++ b/fitsutil.par
@@ -1,2 +1,2 @@
 # fitsutil package parameter file.
-version,s,h,"3Jan2010"
+version,s,h,"2018.07.06"


### PR DESCRIPTION
To make version comparison simpler, we also switch from the `6Jan2010` format to the `2018.07.06` format. In future, this allows an automated test which version is higher.
