### PR TITLE
Fix slines handling in fgwrite.c

### DIFF
--- a/src/fgread.c
+++ b/src/fgread.c
@@ -1,25 +1,19 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+#define _XOPEN_SOURCE
 #include <stdio.h>
 #include <unistd.h>
+#include <stdlib.h>
 #include <ctype.h>
+#include <sys/stat.h>
 #include <sys/types.h>
+#include <fcntl.h>
 #include <string.h>
 #include <pwd.h>
 #include <utime.h>
-/* #include <time.h> */
-
-#ifdef SYSV
 #include <time.h>
-#else
-#include <sys/time.h>
-#include <sys/timeb.h>
-#endif
 
-#if defined(MACOSX) || defined(__linux)
-#include <time.h>
-#endif
 
 #include "kwdb.h"
 static  long get_timezone();
@@ -245,7 +239,7 @@ char	*argv[];
 			    fprintf (stderr, "missing filename argument\n");
 			    exit (1);
 			}
-			in = open (*argp, 0);
+			in = open (*argp, O_RDONLY);
 			if (in == ERR) {
 			    fprintf (stderr, "cannot open `%s'\n", *argp);
 			    exit (1);
@@ -613,7 +607,7 @@ char    *type;			/* Foreign extension type, (bin, text..) */
 
 	tp = ctime (&fh->mtime);
 
-	fprintf (out, "%-4d %-10.10s %9d %-12.12s %-4.4s %s",
+	fprintf (out, "%-4d %-10.10s %9ld %-12.12s %-4.4s %s",
 	    count,type, fh->size, tp + 4, tp + 20, fh->name);
 	if (fh->linkflag && *fh->linkname) {
 	    fprintf (out, " -> %s ", fh->linkname);
@@ -889,21 +883,8 @@ int	ftype;
 static long
 get_timezone()
 {
-#ifdef SYSV
         extern  long timezone;
         tzset();
         return (timezone);
-#else
-#ifdef MACOSX
-        struct tm *tm;
-        time_t clock = time(NULL);
-        tm = localtime (&clock);
-        return (-(tm->tm_gmtoff));
-#else
-        struct timeb time_info;
-        ftime (&time_info);
-        return (time_info.timezone * 60);
-#endif
-#endif
 }
 

--- a/src/fgwrite.c
+++ b/src/fgwrite.c
@@ -3,6 +3,8 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
 #include <fcntl.h>
 #include <time.h>
 #include <strings.h>

--- a/src/kwdb.c
+++ b/src/kwdb.c
@@ -1,5 +1,9 @@
 #include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
 #include <fcntl.h>
+#include <ctype.h>
 #include "kwdb.h"
 
 /*
@@ -146,13 +150,10 @@ struct kwdb {
 	Item *itab;		/* pointer to itab array */
 	char *sbuf;		/* pointer to string buffer */
 	int hashtbl[NTHREADS];	/* hash table */
-	int (*read)();		/* private file read function */
-	int (*write)();		/* private file write function */
+	ssize_t (*read)();		/* private file read function */
+	ssize_t (*write)();		/* private file write function */
 };
 typedef struct kwdb KWDB;
-
-extern char *mkstemp();
-extern int read(), write();
 
 static int hash();
 static int addstr();


### PR DESCRIPTION
Don't increment `slines` after allocation, only reallocate it. Also fix the `realloc()` calling parameters.

This brings `fgwrite` back to work when a reallocation of `slines` was needed (the TOC contained more than 70 entries).

Closes #7.

Also, necessary `#include` statements are added to declare the standard functions.