### PR TITLE
Use mkfloat.sh in mkpkg

### DIFF
--- a/mkpkg
+++ b/mkpkg
@@ -63,7 +63,7 @@ summary:
 arch:					# show current float option
 showfloat:
 	$verbose off
-	!$(hlib)/mkfloat.csh
+	!$(hlib)/mkfloat
 	;
 generic:				# generic installation (no bin)
 	$ifnfile (bin.generic)
@@ -71,7 +71,7 @@ generic:				# generic installation (no bin)
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh generic -d $(DIRS)
+	!$(hlib)/mkfloat generic -d $(DIRS)
 	;
 
 freebsd:                                # install FreeBSD binaries
@@ -80,7 +80,7 @@ freebsd:                                # install FreeBSD binaries
 	$endif
         $verbose off
         $set DIRS = "lib src"
-        !$(hlib)/mkfloat.csh freebsd -d $(DIRS)
+        !$(hlib)/mkfloat freebsd -d $(DIRS)
         ;
 linux:                                  # install Slackwkare Linux binaries
 	$ifnfile (bin.linux)
@@ -88,7 +88,7 @@ linux:                                  # install Slackwkare Linux binaries
 	$endif
         $verbose off
         $set DIRS = "lib src"
-        !$(hlib)/mkfloat.csh linux -d $(DIRS)
+        !$(hlib)/mkfloat linux -d $(DIRS)
         ;
 linux64:                                # install x86_64 binaries
 	$ifnfile (bin.linux64)
@@ -96,7 +96,7 @@ linux64:                                # install x86_64 binaries
 	$endif
         $verbose off
         $set DIRS = "lib src"
-        !$(hlib)/mkfloat.csh linux64 -d $(DIRS)
+        !$(hlib)/mkfloat linux64 -d $(DIRS)
         ;
 macosx:                                 # install Mac OS X (PPC) binaries
 	$ifnfile (bin.macosx)
@@ -104,7 +104,7 @@ macosx:                                 # install Mac OS X (PPC) binaries
 	$endif
         $verbose off
         $set DIRS = "lib src"
-        !$(hlib)/mkfloat.csh macosx -d $(DIRS)
+        !$(hlib)/mkfloat macosx -d $(DIRS)
         ;
 macintel:                               # install Mac OS X (Intel) binaries
 	$ifnfile (bin.macintel)
@@ -112,7 +112,7 @@ macintel:                               # install Mac OS X (Intel) binaries
 	$endif
         $verbose off
         $set DIRS = "lib src"
-        !$(hlib)/mkfloat.csh macintel -d $(DIRS)
+        !$(hlib)/mkfloat macintel -d $(DIRS)
         ;
 cygwin:                                 # install Cygwin binaries
 	$ifnfile (bin.cygwin)
@@ -120,7 +120,7 @@ cygwin:                                 # install Cygwin binaries
 	$endif
         $verbose off
         $set DIRS = "lib src"
-        !$(hlib)/mkfloat.csh cygwin -d $(DIRS)
+        !$(hlib)/mkfloat cygwin -d $(DIRS)
         ;
 redhat:                                 # install Redhat Linux binaries
 	$ifnfile (bin.redhat)
@@ -128,7 +128,7 @@ redhat:                                 # install Redhat Linux binaries
 	$endif
         $verbose off
         $set DIRS = "lib src"
-        !$(hlib)/mkfloat.csh redhat -d $(DIRS)
+        !$(hlib)/mkfloat redhat -d $(DIRS)
         ;
 sparc:					# install sparc binaries
 	$ifnfile (bin.sparc)
@@ -136,7 +136,7 @@ sparc:					# install sparc binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh sparc -d $(DIRS)
+	!$(hlib)/mkfloat sparc -d $(DIRS)
 	;
 ssun:					# install Sun/Solaris binaries
 	$ifnfile (bin.ssun)
@@ -144,7 +144,7 @@ ssun:					# install Sun/Solaris binaries
 	$endif
 	$verbose off
 	$set DIRS = "lib src"
-	!$(hlib)/mkfloat.csh ssun -d $(DIRS)
+	!$(hlib)/mkfloat ssun -d $(DIRS)
 	;
 sunos:                                  # install SunOS (Solaris x86) binaries
 	$ifnfile (bin.sunos)
@@ -152,5 +152,5 @@ sunos:                                  # install SunOS (Solaris x86) binaries
 	$endif
         $verbose off
         $set DIRS = "lib src"
-        !$(hlib)/mkfloat.csh sunos -d $(DIRS)
+        !$(hlib)/mkfloat sunos -d $(DIRS)
         ;


### PR DESCRIPTION
IRAF now uses `/bin/sh` compatible scripts instead of (t)csh. Since the shell name is encoded in the suffix, this needs to be changed in mkpkg.

Closes #9 