### PR TITLE
Add missing tm_isdst initialization

### DIFF
--- a/src/fgread.c
+++ b/src/fgread.c
@@ -469,6 +469,9 @@ char	 *type;			/* Extension type */
 
 	s = kwdb_GetValue (kwdb, "FG_MTIME");	
 
+	/* Not set by strptime(); tells mktime() to determine whether daylight
+	 * saving time is in effect */
+	tm.tm_isdst = -1;
 	strptime (s, "%Y-%m-%dT%T",&tm);
 	fh->mtime = mktime(&tm) - get_timezone();
 


### PR DESCRIPTION
Forwarded from @aurel32 [Debian#939523](https://bugs.debian.org/939523):

> As discussed in [Debian#939048](https://bugs.debian.org/939048), the autopkgtest from iraf-fitsutil fail in a strange way when run with glibc 2.29 instead of glibc 2.28:
> 
>     cl> fitsutil
>     This is the initial release of the IRAF FITSUTIL package
>     to include support for FITS tile compression via 'fpack'.
>     Please send comments and questions to seaman@noao.edu.
>     
>     cl> copy dev$pix.pix pix.pix
>     cl> copy dev$pix.imh pix.imh
>     cl> fgwrite "pix.pix pix.imh" pix.fits verb-
>     cl> mkdir out
>     cl> cd out
>     cl> fgread ../pix.fits "" "" verb-
>     cl> sum32 *
>     ERROR: No write permission on file (String_File)
>        "directory (img, long+) | scan (junk, junk, filsiz)"
>           line 42: fitsutil$src/sum32.cl
>           called as: `sum32 (input=*)'
>           called as: `cl ()'
>        "clbye()"
>           line 41: fitsutil$fitsutil.cl
>           called as: `fitsutil ()'
>           called as: `cl ()'
>      Error while reading login.cl file - may need to rebuild with mkiraf
>      Fatal startup error.  CL dies.
> 
> This happens because the error checking in `mktime()` have been improved in case a non-valid date is provided in the `tm` struct. More precisely in `fgread.c`, it should be noted that `strptime` does NOT setup the `tm_isdst` of `tm struct`, which is instead getting a random value from the stack. For this field 0 means no DST, positive value means DST and negative values means that the value should be computed by `mktime()`.
> 
> In the iraf-fitsutil, `tm_isdst` is not known from the file so it should be set to -1, just like it's done in the POSIX.1-2018 `strptime` example:
> 
> https://pubs.opengroup.org/onlinepubs/9699919799/
> 
> Therefore the following patch fixes the issue.

Thank you @aurel32 for the quick fix!