### PR TITLE
Merge changes from NOIRLABs version

### DIFF
--- a/fitsutil.cl
+++ b/fitsutil.cl
@@ -1,10 +1,5 @@
 #{ FITSUTIL.CL -- The FITSUTIL package
 
-print ("This is the initial release of the IRAF FITSUTIL package")
-print ("to include support for FITS tile compression via 'fpack'.")
-print ("Please send comments and questions to seaman@noao.edu.")
-print ("")
-
 cl < "fitsutil$/lib/zzsetenv.def"
 package	fitsutil, bin = fitsutilbin$
 

--- a/mkpkg
+++ b/mkpkg
@@ -35,7 +35,14 @@ src:
 	$call update@src
 	;
 
-# STRIP -- Strip the TABLES directories of all sources and other files not
+clean:
+	$verbose off
+	$set DIRS = "lib src"
+	!($(hlib)/mkfloat.csh generic -d $(DIRS) ; rm -rf bin.[gbl]* *spool*)
+	;
+
+
+# STRIP -- Strip the FITSUTIL directories of all sources and other files not
 # required to run the system, or for user programming.
 
 strip:
@@ -56,7 +63,6 @@ summary:
 	;
 
 
-
 # IRAF multiple architecture support.
 # ----------------------------------------
 
@@ -73,15 +79,6 @@ generic:				# generic installation (no bin)
 	$set DIRS = "lib src"
 	!$(hlib)/mkfloat generic -d $(DIRS)
 	;
-
-freebsd:                                # install FreeBSD binaries
-	$ifnfile (bin.freebsd)
-	    !mkdir bin.freebsd
-	$endif
-        $verbose off
-        $set DIRS = "lib src"
-        !$(hlib)/mkfloat freebsd -d $(DIRS)
-        ;
 linux:                                  # install Slackwkare Linux binaries
 	$ifnfile (bin.linux)
 	    !mkdir bin.linux
@@ -98,7 +95,7 @@ linux64:                                # install x86_64 binaries
         $set DIRS = "lib src"
         !$(hlib)/mkfloat linux64 -d $(DIRS)
         ;
-macosx:                                 # install Mac OS X (PPC) binaries
+macosx:                                 # install Mac OS X (Apple) binaries
 	$ifnfile (bin.macosx)
 	    !mkdir bin.macosx
 	$endif
@@ -114,43 +111,11 @@ macintel:                               # install Mac OS X (Intel) binaries
         $set DIRS = "lib src"
         !$(hlib)/mkfloat macintel -d $(DIRS)
         ;
-cygwin:                                 # install Cygwin binaries
-	$ifnfile (bin.cygwin)
-	    !mkdir bin.cygwin
+macos64:                                # install Mac OS X alt binaries
+	$ifnfile (bin.macos64)
+	    !mkdir bin.macos64
 	$endif
         $verbose off
         $set DIRS = "lib src"
-        !$(hlib)/mkfloat cygwin -d $(DIRS)
-        ;
-redhat:                                 # install Redhat Linux binaries
-	$ifnfile (bin.redhat)
-	    !mkdir bin.redhat
-	$endif
-        $verbose off
-        $set DIRS = "lib src"
-        !$(hlib)/mkfloat redhat -d $(DIRS)
-        ;
-sparc:					# install sparc binaries
-	$ifnfile (bin.sparc)
-	    !mkdir bin.sparc
-	$endif
-	$verbose off
-	$set DIRS = "lib src"
-	!$(hlib)/mkfloat sparc -d $(DIRS)
-	;
-ssun:					# install Sun/Solaris binaries
-	$ifnfile (bin.ssun)
-	    !mkdir bin.ssun
-	$endif
-	$verbose off
-	$set DIRS = "lib src"
-	!$(hlib)/mkfloat ssun -d $(DIRS)
-	;
-sunos:                                  # install SunOS (Solaris x86) binaries
-	$ifnfile (bin.sunos)
-	    !mkdir bin.sunos
-	$endif
-        $verbose off
-        $set DIRS = "lib src"
-        !$(hlib)/mkfloat sunos -d $(DIRS)
+        !$(hlib)/mkfloat macos64 -d $(DIRS)
         ;

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -1,6 +1,10 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
+/*
+ * CHECKSUM - Checksum utilities.
+ */
+
 /* Explicitly exclude those ASCII characters that fall between the
  * upper and lower case alphanumerics (<=>?@[\]^_`) from the encoding.
  * Which is to say that only the digits 0-9, letters A-Z, and letters
@@ -13,6 +17,18 @@ unsigned exclude[NX] = { 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40,
 int offset = 0x30;		/* ASCII 0 (zero) character */
 
 
+void checksum (unsigned char *buf, int length,
+               unsigned short *sum16, unsigned int *sum32);
+
+void char_encode (unsigned int value, char *ascii,
+                  int nbytes, int permute);
+unsigned int add_1s_comp (unsigned int u1, unsigned int u2);
+unsigned int addcheck (unsigned int *sum, char *array, int length);
+unsigned int addcheck32 (unsigned int *sum, char *array, int length);
+unsigned int addcheck1 (unsigned int *sum, char *array, int length);
+unsigned int addcheck2 (unsigned int *sum, char *array, int length);
+
+
 /* CHECKSUM -- Increment the checksum of a character array.  The
  * calling routine must zero the checksum initially.  Shorts are
  * assumed to be 16 bits, ints 32 bits.
@@ -20,11 +36,13 @@ int offset = 0x30;		/* ASCII 0 (zero) character */
 
 /* Internet checksum algorithm, 16/32 bit unsigned integer version:
  */
-checksum (buf, length, sum16, sum32)
-unsigned char	*buf;
-int		length;
-unsigned short	*sum16;
-unsigned int	*sum32;
+void
+checksum (
+    unsigned char	*buf,
+    int		        length,
+    unsigned short	*sum16,
+    unsigned int	*sum32
+)
 {
 	int	 	len, remain, i;
 	unsigned int	hi, lo, hicarry, locarry, tmp16;
@@ -100,12 +118,13 @@ unsigned int	*sum32;
  * To invert the encoding, simply subtract the offset from each byte
  * and pass the resulting string to checksum.
  */
-
-char_encode (value, ascii, nbytes, permute)
-unsigned int	value;
-char		*ascii;	/* at least 17 characters long */
-int		nbytes;
-int		permute;
+void
+char_encode (
+    unsigned int value,
+    char	 *ascii,	/* at least 17 characters long */
+    int		 nbytes,
+    int		 permute
+)
 {
 	int	byte, quotient, remainder, ch[4], check, i, j, k;
 	char	asc[32];
@@ -160,8 +179,11 @@ int		permute;
  * the same thing using checksum(), but this is a little more obvious.
  * To subtract, just complement (~) one of the arguments.
  */
-unsigned int add_1s_comp (u1, u2)
-unsigned int	u1, u2;
+unsigned int
+add_1s_comp (
+    unsigned int u1,
+    unsigned int u2
+)
 {
 	unsigned int	hi, lo, hicarry, locarry;
 
@@ -188,13 +210,14 @@ unsigned int	u1, u2;
  *                               *
  *********************************/
 
-
 /* Internet (1's complement) checksum:
  */
-unsigned int addcheck (sum, array, length)
-unsigned int *sum;
-char *array;
-int length;
+unsigned int
+addcheck (
+    unsigned int *sum,
+    char *array,
+    int length
+)
 {
 	register int i;
 	unsigned short *iarray;
@@ -217,10 +240,12 @@ int length;
 
 /* Internet checksum, 32 bit unsigned integer version:
  */
-unsigned int addcheck32 (sum, array, length)
-unsigned int *sum;
-char *array;
-int length;
+unsigned int
+addcheck32 (
+    unsigned int *sum,
+    char *array,
+    int length
+)
 {
 	register int i;
 	unsigned int *iarray;
@@ -250,10 +275,12 @@ int length;
 
 /* ICE 16 bit microcode checksum:
  */
-unsigned int addcheck1 (sum, array, length)
-unsigned int *sum;
-char *array;
-int length;
+unsigned int
+addcheck1 (
+    unsigned int *sum,
+    char *array,
+    int length
+)
 {
 	register int i;
 
@@ -266,10 +293,12 @@ int length;
 
 /* BSD 16 bit sum algorithm:
  */
-unsigned int addcheck2 (sum, array, length)
-unsigned int *sum;
-char *array;
-int length;
+unsigned int
+addcheck2 (
+    unsigned int *sum,
+    char *array,
+    int length
+)
 {
 	register int i;
 

--- a/src/checksum.c
+++ b/src/checksum.c
@@ -1,3 +1,6 @@
+/* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
+ */
+
 /* Explicitly exclude those ASCII characters that fall between the
  * upper and lower case alphanumerics (<=>?@[\]^_`) from the encoding.
  * Which is to say that only the digits 0-9, letters A-Z, and letters

--- a/src/fgread.c
+++ b/src/fgread.c
@@ -1,22 +1,6 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
-#define _XOPEN_SOURCE
-#include <stdio.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <fcntl.h>
-#include <string.h>
-#include <pwd.h>
-#include <utime.h>
-#include <time.h>
-
-
-#include "kwdb.h"
-static  long get_timezone();
 /*
  * FGREAD -- Read a MEF FITS file created by fgwrite.
  *
@@ -48,6 +32,21 @@ static  long get_timezone();
  * would extract the FITS extension numbers indicated in the list. The list
  * should not have imbedded spaces.
  */
+
+#define _XOPEN_SOURCE
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <string.h>
+#include <pwd.h>
+#include <time.h>
+#include <utime.h>
+
+#include "kwdb.h"
 
 #define FBLOCK		2880
 #define NBLOCK		20
@@ -96,16 +95,16 @@ struct _modebits {
 	int	code;
 	char	ch;
 } modebits[] = {
-	0400,	'r',
-	0200,	'w',
-	0100,	'x',
-	040,	'r',
-	020,	'w',
-	010,	'x',
-	04,	'r',
-	02,	'w',
-	01,	'x',
-	0,	0
+	{0400,	'r'},
+	{0200,	'w'},
+	{0100,	'x'},
+	{040,	'r'},
+	{020,	'w'},
+	{010,	'x'},
+	{04,	'r'},
+	{02,	'w'},
+	{01,	'x'},
+	{0,	0}
 };
 
 
@@ -115,11 +114,11 @@ static int replace;		/* Replace existing files		*/
 static int printfnames;		/* Print file names			*/
 static int verbose;		/* Print everything			*/
 
-static int eof;
-static int nerrs;
-static char *file_list;
-static int nblocks;
+//static int eof;
+//static int nerrs;
+//static int nblocks;
 static int dlevel;		/* Directory level (1 == top) */
+static char *file_list;
 int	sums = NO;		/* Do not do checksum */
 int	count;
 
@@ -133,20 +132,36 @@ int	omitfitsmef=NO;		/* omit FITS-MEF files 	*/
 unsigned short sum16;
 unsigned int   sum32;
 
+
+static int getheader (int in, struct fheader *fh, int *ftype,
+                       pointer kwdb, char *type);
+static void get_uid (char *s, struct fheader *fh);
+static void get_gid (char *s, struct fheader *fh);
+static void printheader (FILE *out, struct fheader *fh, char *type);
+static int newfile (char *fname, struct fheader *fh, int ftype);
+static void copyheader (int out, pointer kwdb);
+static void copyfile (int in, int out, struct fheader *fh, int ftype);
+static void skipfile (int in, struct fheader *fh, pointer kwdb);
+static void get_range (char *list, int  *xarr);
+static int omit_ftype (int ftype);
+static long get_timezone (void);
+
+extern void checksum (unsigned char *buf, int length,
+                      unsigned short *sum16, unsigned int *sum32);
+extern int symlink (const char *oldpath, const char *newpath);
+
+
 /* MAIN -- "rtar [xtvlef] [names]".  The default operation is to extract all
  * files from the tar format standard input in quiet mode.
  */
-main (argc, argv)
-int	argc;
-char	*argv[];
+int
+main (int argc, char **argv)
 {
 	struct	fheader fh;
 	char	**argp;
-	char	*s, *ip, *p, type[20];
-	char	ascii[161];
+	char	*ip, *p, type[20];
 	int	in = 0, out, omitx;
 	int	ftype, ch, ncards, xarr[100], xcount;
-	int	epos,in_off,nbytes;
 	pointer kwdb;
 
 	int	stat, list;
@@ -202,7 +217,7 @@ char	*argv[];
 			    if (*p == 'm')
 				omitfitsmef = YES;
 			}
-			*argp++;
+			(void) *argp++;
 			break;
 		    case 't':		/* Include filetypes */
 			omittxt = YES;
@@ -227,12 +242,12 @@ char	*argv[];
 			    if (*p == 'm')
 				omitfitsmef = NO;
 			}
-			*argp++;
+			(void) *argp++;
 			break;
 		    case 'n':
 			/* Get list of extension numbers to read */
 			get_range (*argp, xarr);
-			*argp++;
+			(void) *argp++;
 			break;
 		    case 'f':
 			if (*argp == NULL) {
@@ -380,21 +395,20 @@ char	*argv[];
  * file header.  A checksum error on the file header is fatal and usually
  * indicates that the file was not properly transferred.
  */
-getheader (in, fh, ftype, kwdb, type)
-int	in;			/* input file			*/
-register struct	fheader *fh;	/* decoded file header (output)	*/
-int	*ftype;			/* file type			*/
-pointer  kwdb;
-char	 *type;			/* Extension type */
+static int
+getheader (
+    int	            in,		/* input file			*/
+    struct fheader *fh,	        /* decoded file header (output)	*/
+    int	           *ftype,	/* file type			*/
+    pointer         kwdb,
+    char	   *type 	/* Extension type */
+)
 {
-	register char *ip, *op;
-	register int n;
-	char    smode[SLEN];
-	int	ntrys, ncards, hsize, hpos, in_off;
+	int	ncards, hsize, hpos, in_off;
 	int	nbh, bks, i, recsize;
-	char	record[FBLOCK*NBLOCK];
 	char    *s, *p;
 	register struct	_modebits *mp;
+	unsigned char record[FBLOCK*NBLOCK];
 	struct tm tm;
 
 	int   mode=0;
@@ -498,11 +512,14 @@ char	 *type;			/* Extension type */
 	return (FBLOCK);
 }
 
+
 /* GET_UID -- Get the uid for a user name .
 */ 
-get_uid (s, fh)
-char	*s;
-register struct	fheader *fh;	/* decoded file header (output)	*/
+static void
+get_uid (
+    char *s,
+    struct fheader *fh	/* decoded file header (output)	*/
+)
 {
 	static      int uid;
 	static      char owner[SZ_OWNERSTR+1]={'\0'};
@@ -518,12 +535,12 @@ register struct	fheader *fh;	/* decoded file header (output)	*/
 
 	if (!strncmp(s, "<unknown>", 9)) {
 	    fh->uid = getuid();
-	    return (0);
+	    return;
 	}
 
 	if (!strcmp(s,owner)) {;
 	    fh->uid = uid;
-	    return (0);
+	    return;
 	} else {
 	    /* setpwent();  */
 	    pw = getpwnam (s);
@@ -538,11 +555,14 @@ register struct	fheader *fh;	/* decoded file header (output)	*/
 	}
 }
 
+
 /* GET_GID -- Get the gid for a user name .
 */ 
-get_gid (s, fh)
-char	*s;
-register struct	fheader *fh;	/* decoded file header (output)	*/
+static void
+get_gid (
+    char *s,
+    struct fheader *fh	/* decoded file header (output)	*/
+)
 {
 	static      int gid;
 	static      char owner[SZ_OWNERSTR+1]={'\0'};
@@ -558,12 +578,12 @@ register struct	fheader *fh;	/* decoded file header (output)	*/
 
 	if (!strncmp(s, "<unknown>", 9)) {
 	    fh->uid = getgid();
-	    return (0);
+	    return;
 	}
 
 	if (!strcmp(s,owner)) {;
 	    fh->gid = gid;
-	    return (0);
+	    return;
 	} else {
 	    /* setpwent();  */
 	    pw = getpwnam (s);
@@ -578,33 +598,17 @@ register struct	fheader *fh;	/* decoded file header (output)	*/
 	}
 }
 
-/*
-struct _modebits {
-	int	code;
-	char	ch;
-} modebits[] = {
-	040000,	'd',
-	0400,	'r',
-	0200,	'w',
-	0100,	'x',
-	040,	'r',
-	020,	'w',
-	010,	'x',
-	04,	'r',
-	02,	'w',
-	01,	'x',
-	0,	0
-};
-*/
 
 /* PRINTHEADER -- Print the file header in either short or long (verbose)
  * format, e.g.:
  *		drwxr-xr-x  9 tody         1024 Nov  3 17:53 .
  */
-printheader (out, fh, type)
-FILE	*out;			/* output file			*/
-register struct fheader *fh;	/* file header struct		*/
-char    *type;			/* Foreign extension type, (bin, text..) */
+static void
+printheader (
+    FILE *out,			/* output file			    */
+    struct fheader *fh,	        /* file header struct		    */
+    char *type			/* Foreign extn type, (bin, text..) */
+)
 {
 	char	*tp, *ctime();
 
@@ -623,13 +627,15 @@ char    *type;			/* Foreign extension type, (bin, text..) */
  * with the mode bits given.  Create all directories leading to the file if
  * necessary (and possible).
  */
-newfile (fname, fh, ftype)
-char	*fname;			/* pathname of file		*/
-register struct fheader *fh;	/* file header struct		*/
-int	ftype;			/* text, binary, director, etc	*/
+static int
+newfile (
+    char *fname,		/* pathname of file		*/
+    struct fheader *fh,	        /* file header struct		*/
+    int	ftype			/* text, binary, director, etc	*/
+)
 {
 	int	fd;
-	char	*cp, *cwd, dirname[MAXLINELEN];
+	char	*cwd, dirname[MAXLINELEN];
 	int	i, mode, fdirlevel;
 	
 	mode = fh->mode;
@@ -675,13 +681,16 @@ printf("chdir to '%s', fdirlevel: %d, dlevel: %d\n", fname, fdirlevel, dlevel);
 	return (fd);
 }
 
+
 /* COPYHEADER -- Copy the PHU of a FITS or FITS-MEF extension from a 
  * file created by fgwrite. We need to get rid of the FG_ keywords
  * before leaving.
  */
-copyheader (out, kwdb)
-int	out;			/* output file			*/
-pointer kwdb;
+static void
+copyheader (
+    int out,		        /* output file			*/
+    pointer kwdb
+)
 {
 	int ep, ncards, hdr_off, i;
 	char	card[CARDLEN];
@@ -732,23 +741,26 @@ pointer kwdb;
 	write (out, card, CARDLEN);
 }					 
 
+
 /* COPYFILE -- Copy bytes from the input (tar) file to the output file.
  * Each file consists of a integral number of FBLOCK size blocks on the
  * input file.
  */
-copyfile (in, out, fh, ftype)
-int	in;			/* input file			*/
-int	out;			/* output file			*/
-struct	fheader *fh;		/* file header structure	*/
-int	ftype;			/* text or binary file		*/
+static void
+copyfile (
+    int	in,			/* input file			*/
+    int	out,			/* output file			*/
+    struct fheader *fh,		/* file header structure	*/
+    int	ftype			/* text or binary file		*/
+)
 {
 	long	nbytes, bsize;
 	int	i, nblocks;
-	char	buffer[SZ_BUFFER], *p;
+	unsigned char buffer[SZ_BUFFER];
 
 	/* Link files are zero length on the tape. */
 	if (fh->linkflag)
-	    return (0);
+	    return;
 	
 	/* hsize is different from zero for FITS(-MEF) ftype only.
 	 * Also we copy the entire MEF file since its size
@@ -779,17 +791,18 @@ int	ftype;			/* text or binary file		*/
 		    fh->name);
 	    }
 	}
-
 }
 
 
 /* SKIPFILE -- Skip the current FITS unit up to the beginning of the
  * next.
  */
-skipfile (in, fh, kwdb)
-int	in;			/* input file			*/
-struct	fheader *fh;		/* file header			*/
-pointer kwdb;
+static void
+skipfile (
+    int	in,			/* input file			*/
+    struct fheader *fh,		/* file header			*/
+    pointer kwdb
+)
 {
 	int	datasize;
 	int     in_off;
@@ -804,9 +817,11 @@ pointer kwdb;
 /* GET_RANGE -- Parse a string with a list of ranges; e.g. 1,4,5-8,12
  * and put the expanded values in the integer array.
  */
-get_range (list, xarr)
-char *list;
-int  *xarr;
+static void
+get_range (
+    char *list,
+    int  *xarr
+)
 {
 	int   i,j,k,l, n;
 	char  *p;
@@ -848,10 +863,10 @@ int  *xarr;
 	xarr[j] = -1;
 }
 
+
 /* OMIT_FTYPE --  Omit the FITS extension of type ftype */
-int 
-omit_ftype (ftype)
-int	ftype;
+static int
+omit_ftype (int ftype)
 {
 	switch(ftype) {
 	case LF_SYMLINK:
@@ -890,4 +905,3 @@ get_timezone()
         tzset();
         return (timezone);
 }
-

--- a/src/fgread.c
+++ b/src/fgread.c
@@ -272,6 +272,11 @@ main (int argc, char **argv)
 	/* read PHU first */
 	kwdb = kwdb_Open("PHU");
 	ncards = kwdb_ReadFITS (kwdb, in, MAXENTRIES, NULL);
+        if (ncards == 0) {
+	    fprintf (stderr, "Error: Cannot read PHU\n");
+	    fflush (stderr);
+	    exit (1);
+	}
 
 	if (kwdb_Lookup (kwdb, "SIMPLE",0) == 0) {
 	    /* We have a FITS file with no PHU, rewind */
@@ -404,7 +409,7 @@ getheader (
     char	   *type 	/* Extension type */
 )
 {
-	int	ncards, hsize, hpos, in_off;
+	int	ncards, hsize, hpos;
 	int	nbh, bks, i, recsize;
 	char    *s, *p;
 	register struct	_modebits *mp;
@@ -494,10 +499,10 @@ getheader (
 	s = kwdb_GetValue (kwdb, "FG_FUGRP");	
 	get_gid (s, fh);
 
-	in_off = lseek (in, 0, SEEK_CUR); 
+	(void) lseek (in, 0, SEEK_CUR); 
 	/* Calculate header checksum only if the CHECKSUM keyword exists */
 	if (kwdb_GetValue (kwdb, "CHECKSUM") != NULL && sums == YES) {
-	    in_off = lseek (in, hpos, SEEK_SET); 
+	    (void) lseek (in, hpos, SEEK_SET); 
 	    nbh = (ncards + 1 + 35)/36;    /* Fblocks of header */
 	    bks = nbh/NBLOCK;
 	    for (i=1; i<=bks; i++) {
@@ -610,7 +615,7 @@ printheader (
     char *type			/* Foreign extn type, (bin, text..) */
 )
 {
-	char	*tp, *ctime();
+	char	*tp;
 
 	tp = ctime (&fh->mtime);
 
@@ -635,7 +640,7 @@ newfile (
 )
 {
 	int	fd;
-	char	*cwd, dirname[MAXLINELEN];
+	char	dirname[MAXLINELEN];
 	int	i, mode, fdirlevel;
 	
 	mode = fh->mode;
@@ -649,7 +654,7 @@ newfile (
 	        dlevel = fdirlevel;
             }
 	    /* See if directory has been created */
-	    cwd = getcwd (dirname, MAXLINELEN);
+	    (void) getcwd (dirname, MAXLINELEN);
 	    strcat (dirname, "/");
 	    strcat (dirname, fname);
 	    if (access (dirname, F_OK)) {
@@ -692,7 +697,8 @@ copyheader (
     pointer kwdb
 )
 {
-	int ep, ncards, hdr_off, i;
+	//int     hdr_off;
+	int     ep, ncards, i;
 	char	card[CARDLEN];
 	
 	/* Change extension to SIMPLE */
@@ -731,7 +737,7 @@ copyheader (
 	kwdb_DeleteEntry (kwdb, ep);
 
 	ncards = kwdb_WriteFITS (kwdb, out);
-	hdr_off = ((ncards + 1 + 35)/36)*36*80;
+	//hdr_off = ((ncards + 1 + 35)/36)*36*80;
 	memset (card, ' ', CARDLEN);
 	for (i = (ncards+1) % 36;  i < 36;  i++)
 	    write (out, card, CARDLEN);

--- a/src/fgwrite.c
+++ b/src/fgwrite.c
@@ -453,7 +453,7 @@ fgfileout (
 	char	card[CARDLEN], type[20];
 	char	sval[SLEN];
 	register struct	_modebits *mp;
-	char 	*tp, *fn, *get_owner(), *get_group();
+	char 	*tp, *fn;
 	pointer kwdb;
 	int	k, nbh, nbp, usize, in, hdr_plus;
 	long	in_off, out_off;
@@ -826,8 +826,7 @@ get_checksum (
 	unsigned int	sum32;
 	char	record[FBLOCK*NBLOCK];
 	char	ascii[161];
-	unsigned int add_1s_comp();
-	int	i, bks, ncards, pos, recsize, permute;
+	int	i, bks, ncards, recsize, permute;
 	pointer kwdb;
 
 	sum16 = 0;
@@ -838,7 +837,7 @@ get_checksum (
 	 * reading data. Read blocks of FBLOCK*NBLOCK bytes, then read a last 
 	 * partial block FBLOCK*nb bytes.
 	 */
-	pos = lseek (fd, out_offset, SEEK_SET);
+	(void) lseek (fd, out_offset, SEEK_SET);
 
 	bks = nbh/NBLOCK;
 	for (i=1; i<=bks; i++) {
@@ -857,7 +856,7 @@ get_checksum (
 	/* Position the output file at the beginning of the EHDU to 
 	 * read FITS header
 	 */
-	pos = lseek (fd, out_offset, SEEK_SET);
+	(void) lseek (fd, out_offset, SEEK_SET);
 
 	kwdb = kwdb_Open ("PHU");
 	if ((ncards = kwdb_ReadFITS (kwdb, fd, MAXENTRIES, NULL)) < 0) {
@@ -871,12 +870,12 @@ get_checksum (
 	/* Position the output file at the beginning of the EHDU to 
 	 * write back the update FITS header
 	 */
-	pos = lseek (fd, out_offset, SEEK_SET);
+	(void) lseek (fd, out_offset, SEEK_SET);
 	ncards = kwdb_WriteFITS (kwdb, out);
 	kwdb_Close(kwdb);
 
 	/* put file pointer to the EOF position */
-	pos = lseek (fd, 0, SEEK_END);
+	(void) lseek (fd, 0, SEEK_END);
 }
 
 
@@ -891,9 +890,9 @@ printheader (
 )
 {
 	char	*tp;
-	long    clk;
+	//long    clk;
 
-	clk = fh->mtime;
+	//clk = fh->mtime;
 	tp = ctime (&fh->mtime);
 
 	fprintf (fp, "%-4d %-10.10s %9ld %-12.12s %-4.4s %s",
@@ -920,10 +919,10 @@ copyfile (
 )
 {
 	register int	i;
-	int	nbytes, ncards, pos;
+	int	nbytes, ncards;
 	int	npad, nb, bks;
 	char	buf[FBLOCK*10], ascii[161];
-	int	ipos, epos, in_off; 
+	int	ipos, epos;
 	unsigned short	sum16;
 	unsigned int	sum32;
 	pointer  kwdb;
@@ -986,7 +985,7 @@ copyfile (
 		epos = lseek(out, 0, SEEK_CUR);
 		sum16=0; sum32=0;
 		bks = (epos-ipos)/(FBLOCK*10);
-		in_off = lseek(out, ipos, SEEK_SET);
+		(void) lseek(out, ipos, SEEK_SET);
 		for (i=1; i<=bks; i++) {
 		    nbytes = read (out, buf, FBLOCK*10);
 		    checksum ((unsigned char *)buf, nbytes, &sum16, &sum32);
@@ -1000,7 +999,7 @@ copyfile (
 
 	    *datasum = sum32;
 	    /* go to the start of EHU */
-	    pos = lseek (out, out_off, SEEK_SET);
+	    (void) lseek (out, out_off, SEEK_SET);
 
 	    kwdb = kwdb_Open ("PHU");
 	    if ((ncards = kwdb_ReadFITS (kwdb, out, MAXENTRIES, NULL)) < 0) {
@@ -1017,7 +1016,7 @@ copyfile (
 	    /* Position the output file at the beginning of the EHDU to 
 	     * write back the update FITS header
 	     */
-	    pos = lseek (out, out_off, SEEK_SET);
+	    (void) lseek (out, out_off, SEEK_SET);
 	    ncards = kwdb_WriteFITS (kwdb, out);
 	    kwdb_Close(kwdb);
 	}
@@ -1102,8 +1101,8 @@ filetype (
 	register int	n, ch, i;
 	int	 fd, nchars, newline_seen;
 	char	*extn, buf[SZ_TESTBLOCK];
-	int	fits_mef();
 	struct stat fi;
+
 
 	if (lstat(fname, &fi) == 0) {
 	    if ((fi.st_mode & S_IFMT) == S_IFDIR)

--- a/src/fgwrite.c
+++ b/src/fgwrite.c
@@ -1,21 +1,6 @@
 /* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
  */
 
-#include <stdio.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <string.h>
-#include <fcntl.h>
-#include <time.h>
-#include <strings.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <dirent.h>
-#include <pwd.h>
-#include <grp.h>
-
-#include "kwdb.h"
-
 /*
  * FGWRITE -- Write a MEF files with FOREIGN Xtension type.
  *
@@ -33,6 +18,22 @@
  * Usage: "fgwrite [-t <tbdsfm>] [-o <tbdsfm>] [-vdih] [-g <group_name>]
  *		   [-f output_fits_file] [input_files]".
  */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <string.h>
+#include <fcntl.h>
+#include <time.h>
+#include <strings.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <pwd.h>
+#include <grp.h>
+
+#include "kwdb.h"
 
 #define ERR		-1
 #define YES		1
@@ -83,16 +84,16 @@ struct _modebits {
 	int	code;
 	char	ch;
 } modebits[] = {
-	0400,	'r',
-	0200,	'w',
-	0100,	'x',
-	040,	'r',
-	020,	'w',
-	010,	'x',
-	04,	'r',
-	02,	'w',
-	01,	'x',
-	0,	0
+	{0400,	'r'},
+	{0200,	'w'},
+	{0100,	'x'},
+	{040,	'r'},
+	{020,	'w'},
+	{010,	'x'},
+	{04,	'r'},
+	{02,	'w'},
+	{01,	'x'},
+	{0,	0}
 };
 
 int	debug=NO;		/* Print debugging messages		*/
@@ -113,24 +114,50 @@ int	sums = NO;
 int     hdr_off;
 char    *slines;
 
-char	group[SLEN],*gname();
-char	*dname();
-static  char *str();
+char	group[SLEN];
+
+
+static void  putfiles (char *dir, int out, char *path, int *level);
+static void  fgfileout (char *fname, int out, int ftype, char *path, int level);
+static char *get_owner (int fuid);
+static char *get_group (int fuid);
+
+static void  get_checksum (int fd, long out_offset, int nbh,
+                           unsigned int *datasum);
+static void  printheader (FILE *fp, struct fheader *fh, char *type);
+static void  copyfile (int in, struct fheader *fh, int out, int ftype,
+                       int out_off, int nbp, unsigned int *datasum);
+
+static char *dname (char *dir);
+static int   filetype (char *fname);
+static int   fits_mef (char *fname, int filesize);
+static char *str (int n);
+static char *gname (char *name);
+static void  toc_card (struct fheader *fh, int ftype,
+                       int hd_cards, int level, int usize);
+static void  list_toc ( pointer kwdb);
+static int   list_mef (int fd, int usize);
+static int   pix_block (pointer kwdb);
+
+extern void checksum (unsigned char *buf, int length,
+                      unsigned short *sum16, unsigned int *sum32);
+extern void char_encode (unsigned int value, char *ascii,
+                         int nbytes, int permute);
+extern unsigned int add_1s_comp (unsigned int u1, unsigned int u2);
+
 
 /* MAIN -- "fgwrite [-t <tbdlfm>] [-o <tbflfm>] [-vd] [-f fitsfile] [files]".
  * If no files are listed the
  * current directory tree is used as input.  If no output file is specified
  * output is to the standard output.
  */
-main (argc, argv)
-int	argc;
-char	*argv[];
+int
+main (int argc, char *argv[])
 {
 	static	char	*def_flist[1] = {NULL};
 	char	*argp, **flist, *arg, *ip;
-	pointer kwdb, kwtoc;
+	pointer kwdb;
 	char    card[SZ_PATHNAME];
-	char    *sline;
 	int	argno, ftype, i, ncards, level, phu;
 
 	flist       = def_flist;
@@ -343,15 +370,16 @@ done:
 /* PUTFILES -- Put the named directory tree to the output fitsfile.  We chdir
  * to each subdirectory to minimize path searches and speed up execution.
  */
-putfiles (dir, out, path, level)
-char	*dir;			/* directory name		*/
-int	out;			/* output file			*/
-char	*path;			/* pathname of curr. directory	*/
-int	*level;			/* directory level              */
+static void
+putfiles (
+    char *dir,			/* directory name		*/
+    int	out,			/* output file			*/
+    char *path,			/* pathname of curr. directory	*/
+    int	*level			/* directory level              */
+)
 {
 	char	newpath[SZ_PATHNAME+1];
 	char	oldpath[SZ_PATHNAME+1];
-	char	fname[SZ_PATHNAME+1];
 	int	ftype, dirl;
 	DIR	*dfd;
 	struct dirent  *dp;
@@ -367,7 +395,7 @@ int	*level;			/* directory level              */
 	    fflush (stdout);
 	    fprintf (stderr, "cannot open subdirectory `%s%s'\n", path, dir);
 	    fflush (stderr);
-	    return (0);
+	    return;
 	}
 
 	getcwd (oldpath, SZ_PATHNAME);
@@ -381,7 +409,7 @@ int	*level;			/* directory level              */
 	    fflush (stdout);
 	    fprintf (stderr, "cannot change directory to `%s'\n", newpath);
 	    fflush (stderr);
-	    return (0);
+	    return;
 	}
 
 	/* Put each file in the directory to the output file.  Recursively
@@ -411,12 +439,14 @@ int	*level;			/* directory level              */
 
 /* FGFILEOUT -- Write the named file to the output in FITS format.
 */
-fgfileout (fname, out, ftype, path, level)
-char	*fname;			/* file to be output	*/
-int	out;			/* output stream	*/
-int	ftype;			/* file type		*/
-char	*path;			/* current path		*/
-int	level;			/* directory level      */
+static void
+fgfileout (
+    char *fname,		/* file to be output	*/
+    int	out,			/* output stream	*/
+    int	ftype,			/* file type		*/
+    char *path,			/* current path		*/
+    int	level			/* directory level      */
+)
 {
 	struct  stat   fst;
 	struct	fheader fh;
@@ -425,35 +455,35 @@ int	level;			/* directory level      */
 	register struct	_modebits *mp;
 	char 	*tp, *fn, *get_owner(), *get_group();
 	pointer kwdb;
-	int	k, nbh, nbp, usize, in, get_checksum(), hdr_plus;
+	int	k, nbh, nbp, usize, in, hdr_plus;
 	long	in_off, out_off;
 	unsigned int datasum;
-	int	nkw, i, ep, status, ncards, pcount, hd_nlines, hd_cards;
+	int	nkw, i, ep, ncards, pcount, hd_nlines, hd_cards;
 
 	if (debug)
 	    printf ("put file `%s', type %d\n", fname, ftype);
 
 	switch(ftype) {
 	case LF_SYMLINK:
-	    if (omitsymlink) return (0);
+	    if (omitsymlink) return;
 	    break;
 	case LF_BIN:
-	    if (omitbin) return (0);
+	    if (omitbin) return;
 	    break;
 	case LF_TXT:
-	    if (omittxt) return (0);
+	    if (omittxt) return;
 	    break;
 	case LF_DIR:
-	    if (omitdir) return (0);
+	    if (omitdir) return;
 	    break;
 	case FITS:
-	    if (omitfits) return (0);
+	    if (omitfits) return;
 	    break;
 	case FITS_MEF:
-	    if (omitfitsmef) return (0);
+	    if (omitfitsmef) return;
 	    break;
 	default:
-	    return (0);
+	    return;
 	    break;
 	}
 
@@ -461,7 +491,7 @@ int	level;			/* directory level      */
 	    fflush (stdout);
 	    fprintf (stderr, "Warning: cannot open file `%s'\n", fname);
 	    fflush (stderr);
-	    return (0);
+	    return;
 	}
 
 	/* Format and output the file header.
@@ -480,7 +510,7 @@ int	level;			/* directory level      */
 	    fprintf (stderr, 
 		"Warning: could not stat file `%s'\n", fname);
 	    fflush (stderr);
-	    return (0);
+	    return;
 	}
 	fh.uid = fst.st_uid;
 	fh.gid = fst.st_gid;
@@ -516,7 +546,7 @@ int	level;			/* directory level      */
 	    fprintf (stderr, 
 		"Warning: Could not open EHU kwdb `%s'\n", fname);
 	    fflush (stderr);
-	    return (0);
+	    return;
 	}
 
 	hdr_plus = 0;
@@ -706,24 +736,21 @@ emptyfile:
 
 	/* Generate one liner for TOC */
 	if (toc)
-	    toc_card (in, &fh, ftype, hd_cards, level, usize);
+	    toc_card (&fh, ftype, hd_cards, level, usize);
 
 	/* Calculate the checksum now */
 	if (sums == YES)
 	    if ((toc==NO) && fh.size > 0 && !fh.isdir && !fh.linkflag)
 		get_checksum(out, out_off, nbh, &datasum);
-	
 
 	close (in);
 }
 
 /* GET_OWNER -- Obtain user name for the password file given the uid.
 */
-char *
-get_owner(fuid)
-int 	fuid;
+static char *
+get_owner (int fuid)
 {
-
 	/* Get owner name.  Once the owner name string has been retrieved
 	* for a particular (system wide unique) UID, cache it, to speed
 	* up multiple requests for the same UID.
@@ -753,9 +780,8 @@ int 	fuid;
 
 /* GET_GROUP -- Obtain group name for the file given the uid.
 */
-char *
-get_group(fuid)
-int 	fuid;
+static char *
+get_group(int fuid)
 {
 
 	/* Get owner name.  Once the owner name string has been retrieved
@@ -788,18 +814,20 @@ int 	fuid;
 /* CHECKSUM -- Calculate the checksum for a FITS extension unit, including
  * header and data.
 */
-get_checksum (fd, out_offset, nbh, datasum)
-int	fd;			/* file descriptor */
-long	out_offset;		/* offset of the beginning of FITS header */
-int	nbh;			/* number of FBLOCK of header */
-unsigned int *datasum;		/* datasum value */
+static void
+get_checksum (
+    int	fd,			/* file descriptor */
+    long out_offset,		/* offset of the beginning of FITS header */
+    int	nbh,			/* number of FBLOCK of header */
+    unsigned int *datasum	/* datasum value */
+)
 {
 	unsigned short	sum16;
 	unsigned int	sum32;
 	char	record[FBLOCK*NBLOCK];
 	char	ascii[161];
 	unsigned int add_1s_comp();
-	int	i, bks, ncards, ep, pos, recsize, permute;
+	int	i, bks, ncards, pos, recsize, permute;
 	pointer kwdb;
 
 	sum16 = 0;
@@ -815,11 +843,11 @@ unsigned int *datasum;		/* datasum value */
 	bks = nbh/NBLOCK;
 	for (i=1; i<=bks; i++) {
 	    recsize = read (fd, record, FBLOCK*NBLOCK);
-	    checksum (record, recsize, &sum16, &sum32);
+	    checksum ((unsigned char *)record, recsize, &sum16, &sum32);
 	}
 	if (nbh % NBLOCK != 0) {
 	    recsize = read (fd, record, (nbh % 10)*FBLOCK);
-	    checksum (record, recsize, &sum16, &sum32);
+	    checksum ((unsigned char *)record, recsize, &sum16, &sum32);
 	}			
 	/* Now add datasum and checksum and put the result in
 	 * 1's complement with permute in a string.
@@ -851,205 +879,24 @@ unsigned int *datasum;		/* datasum value */
 	pos = lseek (fd, 0, SEEK_END);
 }
 
-/* CHECKSUM -- Increment the checksum of a character array.  The
- * calling routine must zero the checksum initially.  Shorts are
- * assumed to be 16 bits, ints 32 bits.
- */
-
-/* Explicitly exclude those ASCII characters that fall between the
- * upper and lower case alphanumerics (<=>?@[\]^_`) from the encoding.
- * Which is to say that only the digits 0-9, letters A-Z, and letters
- * a-r should appear in the ASCII coding for the unsigned integers.
- */
-#define	NX	13
-unsigned exclude[NX] = { 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40,
-			 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x60 };
-
-int offset = 0x30;		/* ASCII 0 (zero) character */
-
-/* Internet checksum algorithm, 16/32 bit unsigned integer version:
- */
-checksum (buf, length, sum16, sum32)
-char		*buf;
-int		length;
-unsigned short	*sum16;
-unsigned int	*sum32;
-{
-	unsigned short	*sbuf;
-	int	 	len, remain, i;
-	unsigned int	hi, lo, hicarry, locarry, tmp16;
-
-	sbuf = (unsigned short *) buf;
-
-	len = 2*(length / 4);	/* make sure len is even */
-	remain = length % 4;	/* add remaining bytes below */
-
-	/* Extract the hi and lo words - the 1's complement checksum
-	 * is associative and commutative, so it can be accumulated in
-	 * any order subject to integer and short integer alignment.
-	 * By separating the odd and even short words explicitly, both
-	 * the 32 bit and 16 bit checksums are calculated (although the
-	 * latter follows directly from the former in any case) and more
-	 * importantly, the carry bits can be accumulated efficiently
-	 * (subject to short integer overflow - the buffer length should
-	 * be restricted to less than 2**17 = 131072).
-	 */
-	hi = (*sum32 >> 16);
-	lo = (*sum32 << 16) >> 16;
-
-	for (i=0; i < len; i+=2) {
-	    hi += sbuf[i];
-	    lo += sbuf[i+1];
-	}
-
-	/* any remaining bytes are zero filled on the right
-	 */
-	if (remain) {
-	    if (remain >= 1)
-		hi += buf[2*len] * 0x100;
-	    if (remain >= 2)
-		hi += buf[2*len+1];
-	    if (remain == 3)
-		lo += buf[2*len+2] * 0x100;
-	}
-
-	/* fold the carried bits back into the hi and lo words
-	 */
-	hicarry = hi >> 16;
-	locarry = lo >> 16;
-
-	while (hicarry || locarry) {
-	    hi = (hi & 0xFFFF) + locarry;
-	    lo = (lo & 0xFFFF) + hicarry;
-	    hicarry = hi >> 16;
-	    locarry = lo >> 16;
-	}
-
-	/* simply add the odd and even checksums (with carry) to get the
-	 * 16 bit checksum, mask the two to reconstruct the 32 bit sum
-	 */
-	tmp16 = hi + lo;
-	while (tmp16 >> 16)
-	    tmp16 = (tmp16 & 0xFFFF) + (tmp16 >> 16);
-
-	*sum16 = tmp16;
-	*sum32 = (hi << 16) + lo;
-}
-
-
-/* CHAR_ENCODE -- Encode an unsigned integer into a printable ASCII
- * string.  The input bytes are each represented by four output bytes
- * whose sum is equal to the input integer, offset by 0x30 per byte.
- * The output is restricted to alphanumerics.
- *
- * This is intended to be used to embed the complement of a file checksum
- * within an (originally 0'ed) ASCII field in the file.  The resulting
- * file checksum will then be the 1's complement -0 value (all 1's).
- * This is an additive identity value among other nifty properties.  The
- * embedded ASCII field must be 16 or 32 bit aligned, or the characters
- * can be permuted to compensate.
- *
- * To invert the encoding, simply subtract the offset from each byte
- * and pass the resulting string to checksum.
- */
-
-char_encode (value, ascii, nbytes, permute)
-unsigned int	value;
-char		*ascii;	/* at least 17 characters long */
-int		nbytes;
-int		permute;
-{
-	int	byte, quotient, remainder, ch[4], check, i, j, k;
-	char	asc[32];
-
-	for (i=0; i < nbytes; i++) {
-	    byte = (value << 8*(i+4-nbytes)) >> 24;
-
-	    /* Divide each byte into 4 that are constrained to be printable
-	     * ASCII characters.  The four bytes will have the same initial
-	     * value (except for the remainder from the division), but will be
-	     * shifted higher and lower by pairs to avoid special characters.
-	     */
-	    quotient = byte / 4 + offset;
-	    remainder = byte % 4;
-
-	    for (j=0; j < 4; j++)
-		ch[j] = quotient;
-
-	    /* could divide this between the bytes, but the 3 character
-	     * slack happens to fit within the ascii alphanumeric range
-	     */
-	    ch[0] += remainder;
-
-	    /* Any run of adjoining ASCII characters to exclude must be
-	     * shorter (including the remainder) than the runs of regular
-	     * characters on either side.
-	     */
-	    check = 1;
-	    while (check)
-		for (check=0, k=0; k < NX; k++)
-		    for (j=0; j < 4; j+=2)
-			if (ch[j]==exclude[k] || ch[j+1]==exclude[k]) {
-			    ch[j]++;
-			    ch[j+1]--;
-			    check++;
-			}
-
-	    /* ascii[j*nbytes+(i+permute)%nbytes] = ch[j]; */
-	    for (j=0; j < 4; j++)
-		asc[j*nbytes+i] = ch[j];
-	}
-
-	for (i=0; i < 4*nbytes; i++)
-	    ascii[i] = asc[(i+4*nbytes-permute)%(4*nbytes)];
-
-	ascii[4*nbytes] = 0;
-}
-
-/* ADD_1S_COMP -- add two unsigned integer values using 1's complement
- * addition (wrap the overflow back into the low order bits).  Could do
- * the same thing using checksum(), but this is a little more obvious.
- * To subtract, just complement (~) one of the arguments.
- */
-unsigned int add_1s_comp (u1, u2)
-unsigned int	u1, u2;
-{
-	unsigned int	hi, lo, hicarry, locarry;
-
-	hi = (u1 >> 16) + (u2 >> 16);
-	lo = ((u1 << 16) >> 16) + ((u2 << 16) >> 16);
-
-	hicarry = hi >> 16;
-	locarry = lo >> 16;
-
-	while (hicarry || locarry) {
-	    hi = (hi & 0xFFFF) + locarry;
-	    lo = (lo & 0xFFFF) + hicarry;
-	    hicarry = hi >> 16;
-	    locarry = lo >> 16;
-	}
-
-	return ((hi << 16) + lo);
-}
-
 
 /* PRINTHEADER -- Print one line of information per file.
  *
  */
-printheader (fp, fh, type)
-FILE	*fp;			/* output file			*/
-register struct fheader *fh;	/* file header struct		*/
-char	*type;			/* type of file */
+static void
+printheader (
+    FILE *fp,			        /* output file			*/
+    register struct fheader *fh,	/* file header struct		*/
+    char *type			        /* type of file */
+)
 {
-	register struct	_modebits *mp;
-	char	c, *tp, line[CARDLEN];
-	int	k;
-	long clk;
+	char	*tp;
+	long    clk;
 
 	clk = fh->mtime;
 	tp = ctime (&fh->mtime);
 
-	fprintf (fp, "%-4d %-10.10s %9d %-12.12s %-4.4s %s",
+	fprintf (fp, "%-4d %-10.10s %9ld %-12.12s %-4.4s %s",
 	    ++count,type, fh->size, tp + 4, tp + 20, fh->name);
 	if (fh->linkflag && *fh->linkname) {
 	    fprintf (fp, " -> %s ", fh->linkname);
@@ -1061,14 +908,16 @@ char	*type;			/* type of file */
 /* COPYFILE -- Copy bytes from the input file to the output file.  Each file
  * consists of a integral number of FBLOCK size blocks on the output file.
  */
-copyfile (in, fh, out, ftype, out_off, nbp, datasum)
-int	in;			/* input file descriptor	*/
-struct	fheader *fh;		/* file header structure	*/
-int	out;			/* output file descriptor	*/
-int	ftype;			/* file type LF_TXT and others   */
-int	out_off;		/* points to the beginning of EHU */
-int	nbp;			/* number of Fblocks in data unit */
-unsigned int *datasum;		/* output datasum value		*/
+static void
+copyfile (
+    int	in,			/* input file descriptor	*/
+    struct fheader *fh,		/* file header structure	*/
+    int	out,			/* output file descriptor	*/
+    int	ftype,			/* file type LF_TXT and others   */
+    int	out_off,		/* points to the beginning of EHU */
+    int	nbp,			/* number of Fblocks in data unit */
+    unsigned int *datasum	/* output datasum value		*/
+)
 {
 	register int	i;
 	int	nbytes, ncards, pos;
@@ -1092,14 +941,14 @@ unsigned int *datasum;		/* output datasum value		*/
 	        nbytes = read (in, buf, FBLOCK*10);
 	        write (out, buf, nbytes);
 		if (sums == YES)
-		    checksum (buf, nbytes, &sum16, &sum32);
+		    checksum ((unsigned char *)buf, nbytes, &sum16, &sum32);
 		nb = nb + nbytes;
 	    }
 	    if (nbp % 10 != 0) {
 		nbytes = read (in, buf, (nbp % 10)*FBLOCK);
 		write (out, buf, nbytes);
 		if (sums == YES)
-		    checksum (buf, nbytes, &sum16, &sum32);
+		    checksum ((unsigned char *)buf, nbytes, &sum16, &sum32);
 		nb = nb + nbytes;
 	    }			
 	}
@@ -1109,7 +958,7 @@ unsigned int *datasum;		/* output datasum value		*/
 	    write (out, buf, nbytes);
 	    if (ftype != FITS_MEF) {
 		if (sums == YES)
-		    checksum (buf, nbytes, &sum16, &sum32);
+		    checksum ((unsigned char *)buf, nbytes, &sum16, &sum32);
 		nb = nb + nbytes;
 	    }
 	}
@@ -1124,7 +973,7 @@ unsigned int *datasum;		/* output datasum value		*/
 	if ((npad % 2880) > 0) {
 	    memset (buf, i, npad);
 	    if (sums == YES)
-		checksum (buf, npad, &sum16, &sum32);
+		checksum ((unsigned char *)buf, npad, &sum16, &sum32);
 	    write (out, buf, npad);
 	}
 
@@ -1140,15 +989,14 @@ unsigned int *datasum;		/* output datasum value		*/
 		in_off = lseek(out, ipos, SEEK_SET);
 		for (i=1; i<=bks; i++) {
 		    nbytes = read (out, buf, FBLOCK*10);
-		    checksum (buf, nbytes, &sum16, &sum32);
+		    checksum ((unsigned char *)buf, nbytes, &sum16, &sum32);
 		}
 		nbp = (epos-ipos) % (FBLOCK*10);
 		if (nbp != 0) {
 		    nbytes = read (out, buf, nbp);
-		    checksum (buf, nbytes, &sum16, &sum32);
+		    checksum ((unsigned char *)buf, nbytes, &sum16, &sum32);
 		}			
 	    }
-
 
 	    *datasum = sum32;
 	    /* go to the start of EHU */
@@ -1163,7 +1011,7 @@ unsigned int *datasum;		/* output datasum value		*/
 
 	    if (sums == YES) {
 		/* update DATASUM value */
-		sprintf(ascii,"%-10lu",sum32);
+		sprintf(ascii,"%-10lu",(unsigned long)sum32);
 		kwdb_SetValue (kwdb, "DATASUM", ascii);
 	    }
 	    /* Position the output file at the beginning of the EHDU to 
@@ -1180,9 +1028,8 @@ unsigned int *datasum;		/* output datasum value		*/
  * an // sequences into a single /, and make sure the directory pathname ends
  * in a single /.
  */
-char *
-dname (dir)
-char	*dir;
+static char *
+dname (char *dir)
 {
 	register char	*ip, *op;
 	static	char path[SZ_PATHNAME+1];
@@ -1193,7 +1040,7 @@ char	*dir;
 
 	if (op > path && *(op-1) != '/')
 	    *op++ = '/';
-	*op = (char )NULL;
+	*op = '\0';
 
 	return (path);
 }
@@ -1246,8 +1093,10 @@ char *fitsextn[] = {		/* Known FITS file extensions */
  * known binary file extension we assume it is a binary file; otherwise we call
  * os_access to determine the file type.
  */
-filetype (fname)
-char	*fname;			/* name of file to be examined	*/
+static int
+filetype (
+    char *fname			        /* name of file to be examined	*/
+)
 {
 	register char	*ip, *ep;
 	register int	n, ch, i;
@@ -1333,13 +1182,14 @@ char	*fname;			/* name of file to be examined	*/
 /* FITS_MEF -- Determines by reading the FITS file if is FITS (single unit)
 * or a FITS-MEF (multiple units).
 */
-fits_mef(fname, filesize)
-char 	*fname;
-int	filesize;	/* fname size */
+static int
+fits_mef(
+    char  *fname,
+    int	filesize	                /* fname size */
+)
 {
 	int     ncards;
 	int	fd, datasize, size;
-	char	*sval;
 	pointer kwdb;
 
 	if ((fd = open (fname, 0)) <= 0) {;
@@ -1372,8 +1222,7 @@ int	filesize;	/* fname size */
 
 
 static char *
-str (n)
-int	n;
+str (int n)
 {
         static char s[32];
 	sprintf (s, "%d", n);
@@ -1384,13 +1233,13 @@ int	n;
 /* GNAME -- Return a filename with no pre or post '/' if it
  * has any.
  */
-char *gname(name)
-char *name;
+static char *
+gname (char *name)
 {
 	char *ip;
 	
 	ip = rindex(name,'/');
-	if (ip != NULL && *(ip+1) == (char )NULL)
+	if (ip != NULL && *(ip+1) == (char)'\0')
 	    *ip = (char )'\0';
 
 	ip = rindex(name,'/');
@@ -1423,14 +1272,16 @@ char *name;
  * FLEVEL:  Directory level of the unit. 1 is top directory
  * FNAME:   File name for the extension unit
  */
-toc_card (in, fh, ftype, hd_cards, level, usize)
-register struct fheader *fh;	/* file header struct		*/
-int	ftype;			/* type of file */
-int	hd_cards;
-int	level;			/* Directory level */
-int	usize;			/* FITS unit size		*/
+static void
+toc_card (
+    struct fheader *fh,	                /* file header struct		*/
+    int	ftype,			        /* type of file */
+    int	hd_cards,
+    int	level,			        /* Directory level */
+    int	usize			        /* FITS unit size		*/
+)
 {
-	char	type[3], *tp, line[CARDLEN];
+	char	type[3];
 	int	c, k, fsize;
 
 	switch(ftype) {
@@ -1488,8 +1339,10 @@ int	usize;			/* FITS unit size		*/
 /* LIST_TOC -- List and update if necessary the header offset 
  * column because we have gone over one or more FITS blocks with lines of TOC.
  */
-list_toc (kwdb)
-pointer kwdb;        /* Output db */
+static void
+list_toc (
+    pointer kwdb                        /* Output db */
+)
 {
 
 	char    *s, line[CARDLEN];
@@ -1533,12 +1386,13 @@ pointer kwdb;        /* Output db */
 /* LIST_MEF -- Lists the extension units of a mef file when TOC is
  * requested.
  */
-list_mef(fd, usize)
-int	fd;		/* input fd   */
-int	usize;		/* size of MEF PHDU */
+static int
+list_mef(
+    int	fd,		/* input fd   */
+    int	usize		/* size of MEF PHDU */
+)
 {
-	int     ncards, bytepix, pcount, naxes, i, npix;
-	int	stat, foff, datasize;
+	int	ncards, stat, foff, datasize;
 	char	ft, *sval;
 	pointer kwdb;
 
@@ -1580,7 +1434,7 @@ int	usize;		/* size of MEF PHDU */
 	    datasize =  pix_block (kwdb);
 	    ncards = ((ncards + 35)/36)*36;
 	    ++count;
-	    sprintf(slines+TOCLEN*(count-1),"  %-4d %4d %7.7c",count,
+	    sprintf(slines+TOCLEN*(count-1),"  %-4d %4d %c",count,
 		(hdr_off+foff)/2880, ft);
 	    foff = foff + datasize * FBLOCK + ncards * CARDLEN;
 	    if (count >= maxcount) {
@@ -1600,9 +1454,8 @@ int	usize;		/* size of MEF PHDU */
 /* PIX_BLOCK -- Calculate the size of the pixel area for a FITS UNIT
  *  in blocks of 2880.
  */
-pix_block (kwdb)
-pointer	kwdb;
-
+static int
+pix_block (pointer kwdb)
 {
 	char *sval, *spcount, kwname[8];
 	int  bytepix, naxes, npix, i, pcount; 

--- a/src/kwdb.c
+++ b/src/kwdb.c
@@ -1121,8 +1121,8 @@ kwdb_WriteFITS (
 void
 kwdb_SetIO (
     register KWDB *kwdb,
-    ssize_t (*readfcn)(),
-    ssize_t (*writefcn)()
+    ssize_t (*readfcn)(int fd, void *buf, size_t count),
+    ssize_t (*writefcn)(int fd, const void *buf, size_t count)
 )
 {
 	register KWDB *db = (KWDB *) kwdb;

--- a/src/kwdb.c
+++ b/src/kwdb.c
@@ -1,3 +1,6 @@
+/* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
+ */
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/kwdb.h
+++ b/src/kwdb.h
@@ -6,30 +6,76 @@
  */
 typedef void *pointer;
 
-int kwdb_AddEntry (/* kwdb, keyword, value, type, comment */);
-void kwdb_Close (/* kwdb) */);
-int kwdb_CopyEntry (/* kwdb, o_kwdb, o_ep) */);
-int kwdb_DeleteEntry (/* kwdb, ep) */);
-char *kwdb_GetComment (/* kwdb, keyword) */);
-int kwdb_GetEntry (/* kwdb, ep, keyword, value, type, comment */);
-char *kwdb_GetType (/* kwdb, keyword) */);
-char *kwdb_GetValue (/* kwdb, keyword) */);
-int kwdb_Head (/* kwdb) */);
-int kwdb_Len (/* kwdb) */);
-int kwdb_Lookup (/* kwdb, keyword) */);
-char *kwdb_Name (/* kwdb) */);
-char *kwdb_KWName (/* kwdb, ep) */);
-int kwdb_Next (/* kwdb, ep */);
-pointer kwdb_Open (/* kwdbname */);
-int kwdb_SetComment (/* kwdb, keyword, comment */);
-int kwdb_SetType (/* kwdb, keyword, type */);
-int kwdb_SetValue (/* kwdb, keyword, value */);
-int kwdb_Tail (/* kwdb */);
 
-pointer kwdb_OpenFITS (/* filename, maxcards, nblank */);
-int kwdb_UpdateFITS (/* kwdb, filename, update, extend, npad */);
-int kwdb_ReadFITS (/* kwdb, fd, maxcards, nblank */);
-int kwdb_WriteFITS (/* kwdb, fd */);
+#define NTHREADS        797
+#define DEF_SZSBUF      32768
+#define DEF_NKEYWORDS   512
+#define MAX_HASHCHARS   18
+#define SZ_FILEBUF      102400
+
+/* KWDB item descriptor.
+ */
+struct item {
+        int name;               /* item name (optional) */
+        int value, vallen;      /* item value (optional) */
+        int type, typelen;      /* value type (optional) */
+        int comment, comlen;    /* item comment (optional) */
+        int nexthash;           /* next item in hash thread */
+        int nextglob;           /* next item in global list */
+};
+typedef struct item Item;
+
+typedef int  (*PFI)();
+
+struct kwdb {
+        int kwdbname;           /* database name */
+        int maxitems;           /* capacity of itab */
+        int nitems;             /* number of valid items */
+        int itemsused;          /* number of item slots used */
+        int sbuflen;            /* capacity of sbuf */
+        int sbufused;           /* sbuf characters used */
+        int head;               /* itab index of first item */
+        int tail;               /* itab index of last item */
+        Item *itab;             /* pointer to itab array */
+        char *sbuf;             /* pointer to string buffer */
+        int hashtbl[NTHREADS];  /* hash table */
+
+        ssize_t (*read)();      /* private file read function */
+        ssize_t (*write)();     /* private file write function */
+};
+typedef struct kwdb KWDB;
+
+
+pointer kwdb_Open (char *kwdbname);
+void    kwdb_Close (pointer kwdb);
+char   *kwdb_Name (pointer kwdb);
+int     kwdb_Len (pointer kwdb);
+int     kwdb_AddEntry (pointer kwdb, char *keyword, char *value,
+                       char *type, char *comment);
+int     kwdb_Lookup (pointer kwdb, char *keyword, int instance);
+char   *kwdb_GetValue (pointer kwdb, char *keyword);
+int     kwdb_SetValue (pointer kwdb, char *keyword, char *value);
+int     kwdb_SetComment (pointer kwdb, char *keyword, char *comment);
+char   *kwdb_GetComment (pointer kwdb, char *keyword);
+int     kwdb_SetType (pointer kwdb, char *keyword, char *type);
+char   *kwdb_GetType (pointer kwdb, char *keyword);
+int     kwdb_Head (pointer kwdb);
+int     kwdb_Tail (pointer kwdb);
+int     kwdb_Next (pointer kwdb, int ep);
+int     kwdb_DeleteEntry (pointer kwdb, int ep);
+int     kwdb_RenameEntry (pointer kwdb, int ep, char *newname);
+int     kwdb_CopyEntry (pointer kwdb, pointer o_kwdb, int o_ep, char *newname);
+int     kwdb_GetEntry (pointer kwdb, int ep, char **keyword, char **value,
+                       char **type, char **comment);
+char   *kwdb_KWName (pointer kwdb, int ep);
+
+pointer kwdb_OpenFITS (char *filename, int maxcards, int *nblank);
+int     kwdb_ReadFITS (pointer kwdb, int fd, int maxcards, int *nblank);
+int     kwdb_UpdateFITS (register KWDB *kwdb, char *filename,
+                         int update, int extend, int npad);
+int     kwdb_WriteFITS (KWDB *kwdb, int fd);
+void    kwdb_SetIO (register KWDB *kwdb,
+                    ssize_t (*readfcn)(), ssize_t (*writefcn)());
 
 /* Compatibility garbage. */
 #ifndef SEEK_SET

--- a/src/kwdb.h
+++ b/src/kwdb.h
@@ -40,8 +40,10 @@ struct kwdb {
         char *sbuf;             /* pointer to string buffer */
         int hashtbl[NTHREADS];  /* hash table */
 
-        ssize_t (*read)();      /* private file read function */
-        ssize_t (*write)();     /* private file write function */
+                                /* private file read function */
+        ssize_t (*read)(int fd, void *buf, size_t count);
+                                /* private file write function */
+        ssize_t (*write)(int fd, const void *buf, size_t count);
 };
 typedef struct kwdb KWDB;
 

--- a/src/kwdb.h
+++ b/src/kwdb.h
@@ -1,3 +1,6 @@
+/* Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
+ */
+
 /*
  * KWDB.H -- KWDB global definitions.
  */

--- a/src/mkpkg
+++ b/src/mkpkg
@@ -13,20 +13,11 @@ relink:
 	$update libpkg.a
 	$omake x_fxutil.x
 
-#	$link x_fxutil.o libpkg.a -lmef  -ldbc -lxtools -o xx_fitsutil.e
-#	$link x_fxutil.o libpkg.a -lmef -lxtools -o xx_fitsutil.e
 	$link x_fxutil.o libpkg.a -lxtools -o xx_fitsutil.e
-	$ifeq (MACH, linux, redhat, macosx, macintel) then
-            !cc -m32 -c $(HSI_CF) fgwrite.c fgread.c sum32.c checksum.c kwdb.c
-	    !cc -m32 $(HSI_LF) fgwrite.o kwdb.o -o fgwrite.e
-	    !cc -m32 $(HSI_LF) fgread.o kwdb.o checksum.o -o fgread.e
-	    !cc -m32 $(HSI_LF) sum32.o checksum.o -o sum32
-	$else
-            !cc -c $(HSI_CF) fgwrite.c fgread.c sum32.c checksum.c kwdb.c
-	    !cc fgwrite.o kwdb.o checksum.o -o fgwrite.e
-	    !cc fgread.o kwdb.o checksum.o -o fgread.e
-	    !cc sum32.o checksum.o -o sum32
-	$endif
+        !cc -c $(HSI_CF) fgwrite.c fgread.c sum32.c checksum.c kwdb.c
+	!cc $(HSI_LF) fgwrite.o kwdb.o checksum.o -o fgwrite.e
+	!cc $(HSI_LF) fgread.o kwdb.o checksum.o -o fgread.e
+	!cc $(HSI_LF) sum32.o checksum.o -o sum32
 	!rm fgwrite.o fgread.o kwdb.o checksum.o sum32.o
 	;
 

--- a/src/mkpkg
+++ b/src/mkpkg
@@ -23,7 +23,7 @@ relink:
 	    !cc -m32 $(HSI_LF) sum32.o checksum.o -o sum32
 	$else
             !cc -c $(HSI_CF) fgwrite.c fgread.c sum32.c checksum.c kwdb.c
-	    !cc fgwrite.o kwdb.o -o fgwrite.e
+	    !cc fgwrite.o kwdb.o checksum.o -o fgwrite.e
 	    !cc fgread.o kwdb.o checksum.o -o fgread.e
 	    !cc sum32.o checksum.o -o sum32
 	$endif

--- a/src/sum32.c
+++ b/src/sum32.c
@@ -1,3 +1,7 @@
+/* Copyright(c) 1986 Association of Universities for Research in Astronomy
+ * Inc.
+ */
+
 /* SUM32 -- accumulate the 32 bit and 16 bit 1's complement checksums
  * for a file.  Reports the checksums and their complements as well as
  * the size of the file.
@@ -27,25 +31,32 @@
 #define	ERR		0
 #define	OK		1
 
-main (argc, argv)
-int	argc;
-char	*argv[];
+static int checkfile (FILE *fp, unsigned short *sum16, unsigned int *sum32);
+static void print_usage (void);
+
+void checksum (unsigned char *buf, int length,
+               unsigned short *sum16, unsigned int *sum32);
+
+void char_encode (unsigned int value, char *ascii,
+                  int nbytes, int permute);
+
+
+int
+main (int argc, char *argv[])
 {
 	unsigned short	sum16;
 	unsigned int	sum32, tmp16;
-
 	register DIR	*dir;
-
 	int	size, len, iarg, i;
 	int	verbose=0, code=0, inverse=0, got_name=0, num_mode=0, permute=0;
-	char	name[SZ_PATHNAME], ascii[SZ_PATHNAME];
+	char    name[SZ_PATHNAME], ascii[SZ_PATHNAME];
 	FILE	*fp;
 
-/*	if (argc <= 1) {
- *	    print_usage ();
- *	    exit (-1);
- *	}
- */
+
+  	if (argc <= 1) {
+  	    print_usage ();
+  	    exit (-1);
+  	}
 
 	for (iarg=1; iarg < argc; iarg++) {
 	    len = strlen (argv[iarg]);
@@ -103,7 +114,7 @@ char	*argv[];
 		for (i=0; i < size; i++)
 		    name[i] = ascii[i] - 0x30;
 
-	    checksum (name, size, &sum16, &sum32);
+	    checksum ((unsigned char *)name, size, &sum16, &sum32);
 
 	} else if (! got_name) {
 	    size = checkfile (stdin, &sum16, &sum32);
@@ -159,10 +170,12 @@ char	*argv[];
 }
 
 
-int checkfile (fp, sum16, sum32)
-FILE		*fp;
-unsigned short	*sum16;
-unsigned int	*sum32;
+static int
+checkfile (
+    FILE *fp,
+    unsigned short *sum16,
+    unsigned int *sum32
+)
 {
 	char	record[BLOCK*RECORD];
 	int	size, recsize;
@@ -172,8 +185,8 @@ unsigned int	*sum32;
 	size = 0;
 
 	while (! feof (fp))
-	    if (recsize = fread (record, sizeof(char), BLOCK*RECORD, fp)) {
-		checksum (record, recsize, sum16, sum32);
+	    if ((recsize = fread (record, sizeof(char), BLOCK*RECORD, fp))) {
+		checksum ((unsigned char *)record, recsize, sum16, sum32);
 		size += recsize;
 	    }
 
@@ -181,7 +194,8 @@ unsigned int	*sum32;
 }
 
 
-print_usage ()
+static void
+print_usage (void)
 {
 	printf ("usage: sum32 [-v] [-c] [-p] [-i <ascii>] [<file>|<number>]\n");
 }


### PR DESCRIPTION
This PR contains (most of) the changes made in https://github.com/noirlab-iraf/fitsutil

Not applied:
* cfitsio updates (we use the cfitsio library provided by IRAF),
* `mkfloat.sh` usage (we use `mkfloat`; it is better that the tool name does not reflect the used shell type)
* Replacing **realloc()** calls with **calloc()** in https://github.com/noirlab-iraf/fitsutil/commit/008b762a3bbd38db5a073e9536952792da2480ba (see #8)
* Adding and removing binaries
* Re-(ab)using **macosx** as architecture name for Mac/ARM: First, there is no advantage to re-use the name for a different architecture, and then, the name is *wrong* now: the current OS for Macs is called [macOS](https://www.apple.com/macos/) and no longer Mac OS X. **macos64** was [introduced in IRAF 2.17](https://github.com/iraf-community/iraf/pull/131) and will be kept now.

Current status is https://github.com/noirlab-iraf/fitsutil/commit/ecc4f912e8b8326ce18f03368d219ad01c3f5542

Cc @mjfitzpatrick who authored the changes.