### PR TITLE
Revert "Don't try to install cfitsio"

### DIFF
--- a/lib/cfitsio/mkpkg
+++ b/lib/cfitsio/mkpkg
@@ -9,11 +9,9 @@ update:
 	;
 
 link:
-	!cc -c $(HSI_CF) fpack.c
-	!cc -c $(HSI_CF) funpack.c
-	!cc -c $(HSI_CF) fpackutil.c
-	$link fpack.o fpackutil.o -h -lcfitsio -lm 
-	$link funpack.o fpackutil.o -h -lcfitsio -lm
+	$xc -c fpack.c funpack.c fpackutil.c
+	$link -h fpack.o fpackutil.o -lcfitsio
+	$link -h funpack.o fpackutil.o -lcfitsio
 	!rm fpack.o funpack.o fpackutil.o
 	;
 

--- a/lib/mkpkg
+++ b/lib/mkpkg
@@ -11,6 +11,7 @@ install:
 update:
 
 #$update libmef.a
+$call install@cfitsio
 $exit
 
 libmef.a:

--- a/src/mkpkg
+++ b/src/mkpkg
@@ -14,10 +14,10 @@ relink:
 	$omake x_fxutil.x
 
 	$link x_fxutil.o libpkg.a -lxtools -o xx_fitsutil.e
-        !cc -c $(HSI_CF) fgwrite.c fgread.c sum32.c checksum.c kwdb.c
-	!cc $(HSI_LF) fgwrite.o kwdb.o checksum.o -o fgwrite.e
-	!cc $(HSI_LF) fgread.o kwdb.o checksum.o -o fgread.e
-	!cc $(HSI_LF) sum32.o checksum.o -o sum32
+        $xc -c fgwrite.c fgread.c sum32.c checksum.c kwdb.c
+	$link -h fgwrite.o kwdb.o checksum.o
+	$link -h fgread.o kwdb.o checksum.o
+	$link -h sum32.o checksum.o -o sum32
 	!rm fgwrite.o fgread.o kwdb.o checksum.o sum32.o
 	;
 


### PR DESCRIPTION
Reverts iraf-community/iraf-fitsutil#13

Otherwise, the **fpack**/**funpack** utils are not available. We take the opportunity to consequently use **$xc** and **$llink** to compile and link; therefore an external cfitsio must be added as `XC_LFLAGS="… -Lpath/to/cfitsio"` and `XC_CFLAGS="… -Ipath/to/cfitsio"`.