### PR TITLE
Use time_t instead of long to represent timestamps.

### DIFF
--- a/src/fgread.c
+++ b/src/fgread.c
@@ -85,7 +85,7 @@ struct fheader {
 	int	dirlevel;
 	long	size;
 	long	hsize;
-	long	mtime;
+	time_t	mtime;
 	long	chksum;
 	int	linkflag;
 	char	linkname[NAMSIZ];

--- a/src/fgwrite.c
+++ b/src/fgwrite.c
@@ -71,8 +71,8 @@ struct fheader {
 	int	gid;
 	int	isdir;
 	long	size;
-	long	mtime;
-	long	ctime;
+	time_t	mtime;
+	time_t	ctime;
 	long	chksum;
 	int	linkflag;
 	char	linkname[NAMSIZ];


### PR DESCRIPTION
This MR addresses https://github.com/iraf-community/iraf-fitsutil/issues/16

Changes:
 - replaced long with time_t in fgwrite and fgread utilities.

Testing:
 - built Ubuntu package with this change and ran autopkgtest:
[amd64]( https://autopkgtest.ubuntu.com/results/autopkgtest-noble-vpa1977-october-21/noble/amd64/i/iraf-fitsutil/20240411_014712_eeba4@/log.gz) [armhf](https://autopkgtest.ubuntu.com/results/autopkgtest-noble-vpa1977-october-21/noble/armhf/i/iraf-fitsutil/20240411_014546_808a0@/log.gz)