### PR TITLE
Merge changes from NOIRLABs version

### DIFF
--- a/src/checksum.c
+++ b/src/checksum.c
@@ -126,7 +126,8 @@ char_encode (
     int		 permute
 )
 {
-	int	byte, quotient, remainder, ch[4], check, i, j, k;
+	int	byte, quotient, remainder, check, i, j, k;
+        unsigned int ch[4];
 	char	asc[32];
 
 	for (i=0; i < nbytes; i++) {
@@ -248,8 +249,8 @@ addcheck32 (
 )
 {
 	register int i;
-	unsigned int *iarray;
-	int	 len, carry=0, newcarry=0;
+	unsigned int *iarray, carry=0;
+	int	 len, newcarry=0;
 
 	iarray = (unsigned int *) array;
 	len = length / 4;

--- a/src/fgread.c
+++ b/src/fgread.c
@@ -366,7 +366,7 @@ main (int argc, char **argv)
 		    if (sum32 > 0 && sums == YES) {
 		        if (debug) 
 			    printf("CHECKSUM: %d\n",sum32);
-		        if (sum32 != -1 && ftype != FITS_MEF) { 
+		        if ((int)sum32 != -1 && ftype != FITS_MEF) { 
 			    fprintf (stderr,
 			       "**** Checksum error in extension %d (%s)\n",
 			       count, fh.name);

--- a/src/kwdb.c
+++ b/src/kwdb.c
@@ -362,7 +362,7 @@ kwdb_SetValue (
 
 	oldval = db->sbuf + itp->value;
 	memset (oldval, 0, itp->vallen);
-	if (strlen(value) > itp->vallen) {
+	if ((int)strlen(value) > itp->vallen) {
 	    itp->value = addstr (db, value);
 	    itp->vallen = strlen (value);
 	} else
@@ -394,7 +394,7 @@ kwdb_SetComment (
 
 	oldcom = db->sbuf + itp->comment;
 	memset (oldcom, 0, itp->comlen);
-	if (strlen(comment) > itp->comlen) {
+	if ((int)strlen(comment) > itp->comlen) {
 	    itp->comment = addstr (db, comment);
 	    itp->comlen = strlen (comment);
 	} else
@@ -448,7 +448,7 @@ kwdb_SetType (
 
 	oldtype = db->sbuf + itp->type;
 	memset (oldtype, 0, itp->typelen);
-	if (strlen(type) > itp->typelen) {
+	if ((int)strlen(type) > itp->typelen) {
 	    itp->type = addstr (db, type);
 	    itp->typelen = strlen (type);
 	} else


### PR DESCRIPTION
These changes were committed to NOIRLab by @mjfitzpatrick in May 2024:

* fbca4a788c021b13adf72238775dedd50df447c2 fixed sign comparison warning for 'sum32'
* e48250b54af42d0dca651e1f6493e6a89bbb2798 type cast 
* 7b6f4e5a7d296c41ec34fb377c3d38f858b2b203 fix unsigned type comparisons 
* a95deb91bdcab7c5704960b39c2221b60421888a fix invalid type comparisons
