### PR TITLE
Fix documentation of examples

### DIFF
--- a/src/doc/fgread.hlp
+++ b/src/doc/fgread.hlp
@@ -65,21 +65,25 @@ consist of all subsequent extensions until an EHU is encountered which
 starts a new file.
 .ih
 EXAMPLES
-1) Restore extension 2 and 5 from the MEF file 'mef.fits'. First look at
+1. Restore extension 2 and 5 from the MEF file 'mef.fits'. First look at
 listing for the exact extension numbers.
 .nf
 
    cl> fgread mef.fits "" "" extract- 
    cl> fgread mef.fits 2,5 ""
 
-   Notice the double quote symbols to indicate a null list of output
-   files since we want to extract extension 2 and 5.
-
 .fi
-2) Extract 'log1.txt', 'log2.txt' and 'obs23.fits' extensions from the
+
+Notice the double quote symbols to indicate a null list of output
+files since we want to extract extension 2 and 5.
+
+2. Extract 'log1.txt', 'log2.txt' and 'obs23.fits' extensions from the
 input MEF file.
 
+.nf
    cl> fgread mef.fits "" log1.txt,log2.txt,obs23.fits
+.fi
+
 .ih
 BUGS
 .ih

--- a/src/doc/fgwrite.hlp
+++ b/src/doc/fgwrite.hlp
@@ -132,17 +132,18 @@ The file modification GMT time.
 .le
 .ih
 EXAMPLES
-1) Creates a MEF file 'mef.fits' with the default setup.
+1. Creates a MEF file 'mef.fits' with the default setup.
+.nf
+  cl> fgwrite file1.for,test.c,obs.log mef.fits
+.fi
 
-	cl> fgwrite file1.for,test.c,obs.log mef.fits
-
-2) Create an archive of the current directory and its subdirectories
+2. Create an archive of the current directory and its subdirectories
    excluding any symbolic links.
-   
+.nf
    cl> fgwrite . ../zzd_arc.fits exclude=s checksum=yes
-   
-   The ckecksum option is set, so the keyword CHECKSUM, DATASUM and
-   CHECKVER will be present in all unit headers.
+.fi
+The ckecksum option is set, so the keyword CHECKSUM, DATASUM and
+CHECKVER will be present in all unit headers.
 .ih
 BUGS
 .ih

--- a/src/doc/funpack.hlp
+++ b/src/doc/funpack.hlp
@@ -38,14 +38,15 @@ gzip command.
 This task is a wrapper script for the CFITSIO funpack command.
 .ih
 EXAMPLES
-.nf
+
 1. Uncompress a tile compressed file:
 
+.nf
 	im> funpack file3.fits.fz
-
-   The output file is: file3.fits
-
 .fi
+
+The output file is "file3.fits".
+
 .ih
 BUGS
 .ih

--- a/src/doc/fxconvert.hlp
+++ b/src/doc/fxconvert.hlp
@@ -54,8 +54,9 @@ we need to which kind of image we want as output:
 
 .fi
 2. To copy a portion of an image:
-
+.nf
 	cl> fxconvert image[10:20,*] subimage.fits
+.fi
 
 3. To copy several images. The 'imtype' setting is necessary to dot it only
 once until another image type is desire as output. After the reset, a 
@@ -69,13 +70,16 @@ once until another image type is desire as output. After the reset, a
 .fi
 4. To trim an image:
 
+.nf
+
 	cl> fxconvert image[10:20,*] image
+.fi
 
 In the above example the specified section of the input image replaces the
 original input image.  To trim several images using an image template:
-
+.nf
 	cl> fxconvert frame*[1:512,1:512] frame*
-
+.fi
 In this example all images beginning with "frame" are trimmed to 512 x 512.
 
 5. To copy a set of images to a new directory. Notice that the output
@@ -84,9 +88,13 @@ necessarily be the input type.
 
 .nf
 	cl> fxconvert image* directory
-			or
+.fi
+or
+.nf
 	cl> fxconvert image* directory$
-			or
+.fi
+or
+.nf
 	cl> fxconvert image* osdirectory
 .fi
 

--- a/src/doc/fxcopy.hlp
+++ b/src/doc/fxcopy.hlp
@@ -38,18 +38,18 @@ the first extension two as the second extension and so on.
 EXAMPLES
 1. To put together all of the FITS files starting with 'f' into one new output
 file.
-
+.nf
 	im> fxcopy f*.fits bigf.fits new_file=yes
-
+.fi
 2. To copy extensions 1,3,5 from input file g10.fits into a new file. If you 
 want to append to an existent file, set 'new_file = no'.
-
+.nf
 	im> fxcopy g10.fits g3.fit groups="1,3,5" new_file=yes
-
+.fi
 3. Selected extensions from various input files.
-
+.nf
 	im> fxcopy fa.fits[2],fb.fits[5],fb.fits[7] fall.fits
-
+.fi
 .ih
 BUGS
 Fxcopy does not accept sections in the filename nor extension numbers. 

--- a/src/doc/fxdelete.hlp
+++ b/src/doc/fxdelete.hlp
@@ -30,20 +30,22 @@ Notice that if you delete the PHU (group zero), fxdelete will not create
 a dummy PHU on the modified file.
 .ih
 EXAMPLES
-.nf
 1. Delete group 3 from input.fits.
-
+.nf
 	im> fxdelete input.fits[3]
+.fi
 
 2. To delete extensions 1,3,5 from input file g10.fits.
+.nf
 
 	im> fxdelete g10.fits groups="1,3,5"
+.fi
 
 3. Delete extensions. Notice that for those files without an extension, the
    group extension list applies.
+.nf
 
 	im> fxdelete fa.fits,fb.fits[5],fc.fits groups="1,3,4"
-
 .fi
 .ih
 BUGS

--- a/src/doc/fxdummyh.hlp
+++ b/src/doc/fxdummyh.hlp
@@ -22,9 +22,8 @@ Fxdummyh will create a dataless Primary FITS file with an optional
 user header information.
 .ih
 EXAMPLES
-.nf
 1. Create a new dataless FITS file with user FITS header file.
-
+.nf
 	im> fxdummyh file3.fits hdr_file=myhdr.txt
 
 .fi

--- a/src/doc/fxextract.hlp
+++ b/src/doc/fxextract.hlp
@@ -45,9 +45,9 @@ EXAMPLES
 1. To extract extension 2,4,5 from a file and not produce a PHU for
 each of them. The output files will be extf2.fits, extf4.fits and 
 extf5.fits.
-
+.nf
 	im> fxextract mef.fits extf.fits groups=2,4,5 phu=no
-
+.fi
 .ih
 BUGS
 .ih

--- a/src/doc/fxinsert.hlp
+++ b/src/doc/fxinsert.hlp
@@ -30,20 +30,23 @@ FITS extensions are numbered from zero -as the primary unit, with one as
 the first extension two as the second extension and so on.
 .ih
 EXAMPLES
-.nf
 1. Insert group 3 from input.fits after group 1 from output.fits file.
 
+.nf
 	im> fxinsert input.fits[3] output.fits[1]
+.fi
 
 2. To insert extensions 1,3,5 from input file g10.fits after group 5 from
    g30.fits file.
 
+.nf
 	im> fxinsert g10.fits g30.fits[5] groups="1,3,5"
+.fi
 
 3. Insert files and extensions.
 
+.nf
 	im> fxinsert fa.fits,fb.fits[5],fc.fits foutput.fits[3]
-
 .fi
 .ih
 BUGS

--- a/src/doc/fxplf.hlp
+++ b/src/doc/fxplf.hlp
@@ -30,9 +30,9 @@ created before appending the BINTABLE extension.
 EXAMPLES
 1. To put together all of the Pixel list files starting with 'f'
 into one new output FITS file.
-
+.nf
 	im> fxplf f*.pl bigplf.fits 
-
+.fi
 .ih
 BUGS
 Fxcopy does not accept sections in the filename nor extension numbers. 

--- a/src/doc/fxsplit.hlp
+++ b/src/doc/fxsplit.hlp
@@ -21,17 +21,18 @@ FITS files. The output file names are similar to the input file but they
 will have a count number appended to the root name.
 .ih
 EXAMPLES
-.nf
 1. Split a MEF file that have 2 extensions.
 
+.nf
 	im> fxsplit file3.fits
+.fi
 
    The output file are: file30.fits, file31.fits file32.fits	 
 
 2. To split 2 or more MEF files.
 
+.nf
 	im> fxsplit g10.fits,msc.fits 
-
 .fi
 .ih
 BUGS

--- a/src/doc/ricepack.hlp
+++ b/src/doc/ricepack.hlp
@@ -89,23 +89,29 @@ may result in oversampling the bright end of the dynamic range by a
 factor of several hundred.
 .ih
 EXAMPLES
-.nf
 1. Tile compress a file using the default Rice algorithm
 
+.nf
 	fitsutil> ricepack file3.fits
+.fi
 
    The output file is: file3.fits.fz
 
 2. Compress a mixed list of images:
 
+.nf
 	fitsutil> ricepack *.fits,*.imh,*.fits.gz
+.fi
 
 3. Compress a file and retain the original:
 
+.nf
 	fitsutil> ricepack file4.fits keep+
+.fi
 
 4. Uncompress gzipped files and recompress using Rice in one step:
 
+.nf
 	fitsutil> ricepack *.gz
 	1.1.3 (March 2009) CFITSIO version  3.140
 
@@ -122,7 +128,6 @@ EXAMPLES
 	 saved:      10.849 MB, 19%
 
 	relative R = 1.24
-
 .fi
 The Rice compressed files save 19% of the space (10.849 MB in this case)
 required for the gzip files; the relative compression ratio is 1.24

--- a/src/doc/sum32.hlp
+++ b/src/doc/sum32.hlp
@@ -31,9 +31,9 @@ so treated will be reported as "sum_zeroed" in the task output.  The file
 size in bytes is also reported.
 .ih
 EXAMPLES
-.nf
 1. Report the 1's complement checksum for a list of files:
 
+.nf
 	fitsutil> sum32 *.fits
 	sum_zeroed       584640 test1.fits.fz
 	1363490151       532800 test2.fits


### PR DESCRIPTION
The examples were often lazily formatted, with either completely being in a `.nf`/`.fi` (preformatted/code) section or completely outside, like for **fgwrite**:

>  2) Create an archive of the current directory and its subdirectories excluding any symbolic links. cl> fgwrite . ../zzd_arc.fits exclude=s checksum=yes The ckecksum option is set, so the keyword CHECKSUM, DATASUM and CHECKVER will be present in all unit headers.


This PR corrects this:

> 2. Create an archive of the current directory and its subdirectories excluding any symbolic links. 
>
>         cl> fgwrite . ../zzd_arc.fits exclude=s checksum=yes 
> The ckecksum option is set, so the keyword CHECKSUM, DATASUM and CHECKVER will be present in all unit headers.
